### PR TITLE
Add missing sections to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-?siddhi-io-sqs
+siddhi-io-sqs
 ======================================
 
 The **siddhi-io-sqs extension** is an extension to <a target="_blank" href="https://wso2.github.io/siddhi">Siddhi</a> 
@@ -20,6 +20,9 @@ Find some useful links below:
 ## Latest API Docs 
 
 Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-sqs/api/1.0.1">1.0.1</a>.
+
+# Features
+
 
 ## How to use
 
@@ -43,12 +46,6 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 ```
 
 
-
-
-
-
-
-
  * Post your questions with the <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">"Siddhi"</a> tag in <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">Stackoverflow</a>.
 
  * Siddhi developers can be contacted via the mailing lists:
@@ -61,3 +58,25 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 * We are committed to ensuring support for this extension in production. Our unique approach ensures that all support leverages our open development methodology and is provided by the very same engineers who build the technology.
 
 * For more details and to take advantage of this unique opportunity contact us via <a target="_blank" href="http://wso2.com/support?utm_source=gitanalytics&utm_campaign=gitanalytics_Jul17">http://wso2.com/support/</a>.
+
+## How to Contribute
+ 
+  * Please report issues at <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-sqs/issues">GitHub Issue Tracker</a>.
+  
+  * Send your contributions as pull requests to <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-sqs/tree/master">master branch</a>. 
+ 
+## Contact us 
+
+ * Post your questions with the <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">"Siddhi"</a> tag in <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">Stackoverflow</a>. 
+ 
+ * Siddhi developers can be contacted via the mailing lists:
+ 
+    Developers List   : [dev@wso2.org](mailto:dev@wso2.org)
+    
+    Architecture List : [architecture@wso2.org](mailto:architecture@wso2.org)
+ 
+## Support 
+
+* We are committed to ensuring support for this extension in production. Our unique approach ensures that all support leverages our open development methodology and is provided by the very same engineers who build the technology. 
+
+* For more details and to take advantage of this unique opportunity contact us via <a target="_blank" href="http://wso2.com/support?utm_source=gitanalytics&utm_campaign=gitanalytics_Jul17">http://wso2.com/support/</a>. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-?siddhi-io-sqs
+siddhi-io-sqs
 ======================================
 
 The **siddhi-io-sqs extension** is an extension to <a target="_blank" href="https://wso2.github.io/siddhi">Siddhi</a> 
@@ -21,6 +21,8 @@ Find some useful links below:
 
 Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-io-sqs/api/1.0.1">1.0.1</a>.
 
+## Features
+
 ## How to use
 
 
@@ -42,13 +44,6 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
      </dependency>
 ```
 
-
-
-
-
-
-
-
  * Post your questions with the <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">"Siddhi"</a> tag in <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">Stackoverflow</a>.
 
  * Siddhi developers can be contacted via the mailing lists:
@@ -61,3 +56,25 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 * We are committed to ensuring support for this extension in production. Our unique approach ensures that all support leverages our open development methodology and is provided by the very same engineers who build the technology.
 
 * For more details and to take advantage of this unique opportunity contact us via <a target="_blank" href="http://wso2.com/support?utm_source=gitanalytics&utm_campaign=gitanalytics_Jul17">http://wso2.com/support/</a>.
+
+## How to Contribute
+ 
+  * Please report issues at <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-sqs/issues">GitHub Issue Tracker</a>.
+  
+  * Send your contributions as pull requests to <a target="_blank" href="https://github.com/wso2-extensions/siddhi-io-sqs/tree/master">master branch</a>. 
+ 
+## Contact us 
+
+ * Post your questions with the <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">"Siddhi"</a> tag in <a target="_blank" href="http://stackoverflow.com/search?q=siddhi">Stackoverflow</a>. 
+ 
+ * Siddhi developers can be contacted via the mailing lists:
+ 
+    Developers List   : [dev@wso2.org](mailto:dev@wso2.org)
+    
+    Architecture List : [architecture@wso2.org](mailto:architecture@wso2.org)
+ 
+## Support 
+
+* We are committed to ensuring support for this extension in production. Our unique approach ensures that all support leverages our open development methodology and is provided by the very same engineers who build the technology. 
+
+* For more details and to take advantage of this unique opportunity contact us via <a target="_blank" href="http://wso2.com/support?utm_source=gitanalytics&utm_campaign=gitanalytics_Jul17">http://wso2.com/support/</a>. 


### PR DESCRIPTION
## Purpose
Following sections were missing in the documentation shown in gh-pages,
 - Features
 - How To Contribute
 - Contact us
 - Support

This PR will add these sections to the gh-pages.